### PR TITLE
Wait child process terminate after sending killsig

### DIFF
--- a/clientFactory.cc
+++ b/clientFactory.cc
@@ -237,7 +237,7 @@ void clientItem::processInput(const char *buf, int len)
                 const char *msg = NL "@@@ Got a kill command" NL;
                 PRINTF ("Got a kill command\n");
                 SendToAll(msg, strlen(msg), NULL);
-                processFactorySendSignal(killSig);
+                processClass::terminateWithSignal(killSig);
             }
         }
         SendToAll(buf, len, this);

--- a/procServ.cc
+++ b/procServ.cc
@@ -475,38 +475,44 @@ int main(int argc,char * argv[])
     memset(&sig, 0, sizeof(sig));
 
     PRINTF("Installing signal handlers\n");
-    
+
     // SIGPIPE, SIGTERM and SIGHUP will be handled in the main loop
     // with the assistance of pselect. This means that we have them
     // blocked outside of pselect call, but unblocked atomically
     // within pselect. Each time pselect returns, we safely check if
     // any of the signals were received.
-    
-    // Block the signals that we bill be handling in the main loop.
+
+    // Block the signals that we will be handling in the main loop
+    // and re-enable them during pselect.
     // At the same time, retrieve the original signal mask before
-    // blocking, to be passed to pselect.
+    // blocking, to be passed to the child processes.
+
     sigset_t sigset_block;
+    sigset_t sigset_child;
     sigset_t sigset_pselect;
     sigemptyset(&sigset_block);
     sigaddset(&sigset_block, SIGPIPE);
     sigaddset(&sigset_block, SIGTERM);
     sigaddset(&sigset_block, SIGHUP);
-    sigprocmask(SIG_BLOCK, &sigset_block, &sigset_pselect);
-    
+    sigaddset(&sigset_block, SIGXFSZ);
+    if (inFgMode) {
+        sigaddset(&sigset_block, SIGINT);
+        sigaddset(&sigset_block, SIGQUIT);
+    }
+    sigprocmask(SIG_BLOCK, &sigset_block, &sigset_child);
+
+    // enable SIGPIPE, SIGTERM and SIGHUP during pselect
+    sigprocmask(0, NULL, &sigset_pselect);
+    sigdelset(&sigset_pselect, SIGTERM);
+    sigdelset(&sigset_pselect, SIGHUP);
+    sigdelset(&sigset_pselect, SIGPIPE);
+
     sig.sa_handler = &OnSigPipe;              // sigaction() needed for Solaris
     sigaction(SIGPIPE, &sig, NULL);
     sig.sa_handler = &OnSigTerm;
     sigaction(SIGTERM, &sig, NULL);
     sig.sa_handler = &OnSigHup;
     sigaction(SIGHUP, &sig, NULL);
-    sig.sa_handler = SIG_IGN;
-    sigaction(SIGXFSZ, &sig, NULL);
-    if (inFgMode) {
-        sig.sa_handler = SIG_IGN;
-        sigaction(SIGINT, &sig, NULL);
-        sig.sa_handler = SIG_IGN;
-        sigaction(SIGQUIT, &sig, NULL);
-    }
 
     // Make an accept item to listen for control connections
     PRINTF("Creating control listener\n");
@@ -657,7 +663,7 @@ int main(int argc,char * argv[])
                   PRINTF("Option oneshot is set... exiting\n");
                   shutdownServer = true;
                 } else {
-                  npi= processFactory(childExec, childArgv, &sigset_pselect);
+                  npi= processFactory(childExec, childArgv, &sigset_child);
                   if (npi) AddConnection(npi);
                   if (firstRun) {
                   	firstRun = false;

--- a/procServ.cc
+++ b/procServ.cc
@@ -657,7 +657,7 @@ int main(int argc,char * argv[])
                   PRINTF("Option oneshot is set... exiting\n");
                   shutdownServer = true;
                 } else {
-                  npi= processFactory(childExec, childArgv);
+                  npi= processFactory(childExec, childArgv, &sigset_pselect);
                   if (npi) AddConnection(npi);
                   if (firstRun) {
                   	firstRun = false;

--- a/procServ.h
+++ b/procServ.h
@@ -87,7 +87,7 @@ void DeleteConnection(connectionItem *ci);
 // constructors are public:
 
 // processFactory creates the process that we are managing
-connectionItem * processFactory(char *exe, char *argv[]);
+connectionItem * processFactory(char *exe, char *argv[], sigset_t *sigset);
 bool processFactoryNeedsRestart(); // Call to test status of the server process
 void processFactorySendSignal(int signal);
 

--- a/processClass.h
+++ b/processClass.h
@@ -15,11 +15,11 @@
 
 class processClass : public connectionItem
 {
-friend connectionItem * processFactory(char *exe, char *argv[]);
+friend connectionItem * processFactory(char *exe, char *argv[], sigset_t *sigset);
 friend bool processFactoryNeedsRestart();
 friend void processFactorySendSignal(int signal);
 public:
-    processClass(char *exe, char *argv[]);
+    processClass(char *exe, char *argv[], sigset_t *sigset);
     void readFromFd(void);
     int Send(const char *,int);
     void markDeadIfChildIs(pid_t pid) { if (pid==_pid) _markedForDeletion=true; }

--- a/processClass.h
+++ b/processClass.h
@@ -28,12 +28,14 @@ public:
     virtual bool isLogger() const { return false; }
     static void restartOnce ();
     static bool exists() { return _runningItem ? true : false; }
+    static void terminateWithSignal(int signal);
     virtual ~processClass();
 protected:
     pid_t _pid;
     static processClass * _runningItem;
     static time_t _restartTime;
     void terminateJob();
+    pid_t waitChildrenExitWithTimeout(const struct timespec &timeout);
 #ifdef __CYGWIN__
     HANDLE _hwinjob;
 #endif /* __CYGWIN__ */

--- a/processFactory.cc
+++ b/processFactory.cc
@@ -340,6 +340,13 @@ pid_t processClass::waitChildrenExitWithTimeout(const struct timespec &timeout)
 
 void processClass::terminateWithSignal(int signal)
 {
+    sigset_t previous;
+    sigset_t block;
+
+    sigprocmask(0, NULL, &block);
+    sigaddset(&block, SIGCHLD);
+    sigprocmask(SIG_SETMASK, &block, &previous);
+
     processFactorySendSignal(signal);
 
     auto status = _runningItem->waitChildrenExitWithTimeout({.tv_sec = 5});
@@ -351,6 +358,8 @@ void processClass::terminateWithSignal(int signal)
     }
 
     _runningItem->terminateJob();
+
+    sigprocmask(SIG_SETMASK, &previous, NULL);
 }
 
 void processClass::terminateJob()


### PR DESCRIPTION
A custom termination signal can be configured with --killsig argument to
be sent to the child process, which can handle it for proper
termination. However, right after such signal is sent, child is marked
to be deleted by `DeleteConnection()` through ~processClass(), which
will SIGKILL the process. This double-killing can take milliseconds and
gives no room for a child handler to be completely executed, besides
leading to multiple SIGKILL when default --killsig=9 is used.

Wait for a SIGCHLD up to half a second before forcibly terminating it. A
timeout of 0.5s has been chosen to keep consistent with the amount of
delay already perceived for other child interactions, including normal
termination and restart.